### PR TITLE
add terraform template for bot channel registration

### DIFF
--- a/terraform/azure/bot.tf
+++ b/terraform/azure/bot.tf
@@ -1,0 +1,11 @@
+data "azurerm_client_config" "current" {}
+
+
+
+resource "azurerm_bot_channels_registration" "oas_callback_bot" {
+  name                = "oas_callback_bot"
+  location            = var.location
+  resource_group_name = var.resource_group_name
+  sku                 = "F0"
+  microsoft_app_id    = "${data.azurerm_client_config.current.client_id}"
+}


### PR DESCRIPTION
Hi Ben, I just found that we also need to create a bot channel registration in Azure so I can test it

https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/bot_channels_registration
![Screen Shot 2021-09-28 at 17 01 49](https://user-images.githubusercontent.com/57013495/135181434-302066f2-0a91-4a4d-93de-73ec85b901c7.png)

I just create this pr, please help to take a look. thanks